### PR TITLE
Added filter property to configuration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ into build/generated-sources/velocity:
 
 	velocity {
 		includeDir ...
+		filter = '**/*.vtl'
 
 		context {
 			// Configure a HashMap with context values.

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -15,13 +15,13 @@
 		mavenCentral()
 		// jcenter()
 	}
-	
+
     publishing {
-      publications {
-        mavenJar(MavenPublication) {
-          from components.java
-        }
-      }
+        publications {
+            mavenJar(MavenPublication) {
+        	  	from components.java
+        	}
+      	}
     }
 
 	dependencies {

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -2,6 +2,8 @@
 	// apply plugin: 'errorprone'
 	apply plugin: 'info'
 	apply plugin: 'com.github.ben-manes.versions'
+	apply plugin: 'eclipse'
+	apply plugin: 'maven-publish'
 
 	sourceCompatibility = 1.6
 
@@ -13,6 +15,14 @@
 		mavenCentral()
 		// jcenter()
 	}
+	
+    publishing {
+      publications {
+        mavenJar(MavenPublication) {
+          from components.java
+        }
+      }
+    }
 
 	dependencies {
 		compile 'com.google.code.findbugs:jsr305:2.0.2'

--- a/src/main/java/org/anarres/gradle/plugin/velocity/VelocityPlugin.java
+++ b/src/main/java/org/anarres/gradle/plugin/velocity/VelocityPlugin.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -62,6 +63,13 @@ public class VelocityPlugin implements Plugin<Project> {
                     @Override
                     public Map<String, Object> call() {
                         return extension.contextValues;
+                    }
+                });
+
+                task.conventionMapping("filter", new Callable<String>() {
+                    @Override
+                    public String call() throws Exception {
+                        return extension.filter;
                     }
                 });
             }

--- a/src/main/java/org/anarres/gradle/plugin/velocity/VelocityPluginExtension.java
+++ b/src/main/java/org/anarres/gradle/plugin/velocity/VelocityPluginExtension.java
@@ -1,6 +1,7 @@
 package org.anarres.gradle.plugin.velocity;
 
 import groovy.lang.Closure;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -18,9 +19,11 @@ public class VelocityPluginExtension {
 
     public static final String DEFAULT_INPUT_DIR = "src/main/velocity";
     public static final String DEFAULT_OUTPUT_DIR = "build/generated-sources/velocity";
+    public static final String DEFAULT_FILTER_REGEX = "**/*.java";
 
     public Object inputDir = DEFAULT_INPUT_DIR;
     public Object outputDir = DEFAULT_OUTPUT_DIR;
+    public String filter = DEFAULT_FILTER_REGEX;
     public List<Object> includeDirs = new ArrayList<Object>();
     public Map<String, Object> contextValues = new HashMap<String, Object>();
 

--- a/src/main/java/org/anarres/gradle/plugin/velocity/VelocityTask.java
+++ b/src/main/java/org/anarres/gradle/plugin/velocity/VelocityTask.java
@@ -38,7 +38,7 @@ public class VelocityTask extends ConventionTask {
     private File inputDir;
     private File outputDir;
 
-    private String filter = "**/*.java";
+    private String filter;
     private List<File> includeDirs;
     private Map<String, Object> contextValues;
 
@@ -123,7 +123,7 @@ public class VelocityTask extends ConventionTask {
         setProperty(engine, VelocityEngine.RUNTIME_LOG_LOGSYSTEM_CLASS, SystemLogChute.class.getName());
         setProperty(engine, VelocityEngine.RESOURCE_LOADER, "file");
         setProperty(engine, VelocityEngine.FILE_RESOURCE_LOADER_CACHE, "true");
-        // FILE_RESOURCE_LOADER_PATH actually takes a comma separated list. 
+        // FILE_RESOURCE_LOADER_PATH actually takes a comma separated list.
         StringBuilder includeBuf = new StringBuilder();
         includeBuf.append(inputDir.getAbsolutePath());
         for (File includeDir : getIncludeDirs()) {

--- a/src/test/java/org/anarres/gradle/plugin/velocity/VelocityPluginApplyTest.java
+++ b/src/test/java/org/anarres/gradle/plugin/velocity/VelocityPluginApplyTest.java
@@ -1,15 +1,12 @@
 package org.anarres.gradle.plugin.velocity;
 
 import java.util.Collections;
-
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
-
 import static org.junit.Assert.*;
 
 /**
@@ -34,29 +31,5 @@ public class VelocityPluginApplyTest {
         assertNotNull("Project is missing velocity task", task);
         assertTrue("Velocity task is the wrong type", task instanceof DefaultTask);
         assertTrue("Velocity task should be enabled", ((DefaultTask) task).isEnabled());
-    }
-
-    @Test
-    public void setCustomFilter() {
-        project.apply(Collections.singletonMap("plugin", "java"));
-        project.apply(Collections.singletonMap("plugin", "velocity"));
-
-        ExtensionContainer extensions = project.getExtensions();
-        VelocityPluginExtension dsl = (VelocityPluginExtension) extensions.getByName("velocity");
-
-        // Retrieve plugin task and verify default values
-        VelocityTask task = (VelocityTask) project.getTasks().findByName("velocityVpp");
-        String filter = task.getFilter();
-        assertEquals(VelocityPluginExtension.DEFAULT_FILTER_REGEX, filter);
-
-        // Modify the PluginExtensions filter
-        String testValue = "myFilter";
-        dsl.filter = testValue;
-
-        // Verify that plugin task has the new value for filter
-        task = (VelocityTask) project.getTasks().findByName("velocityVpp");
-        filter = task.getFilter();
-
-        assertEquals(testValue, filter);
     }
 }

--- a/src/test/java/org/anarres/gradle/plugin/velocity/VelocityPluginApplyTest.java
+++ b/src/test/java/org/anarres/gradle/plugin/velocity/VelocityPluginApplyTest.java
@@ -1,12 +1,15 @@
 package org.anarres.gradle.plugin.velocity;
 
 import java.util.Collections;
+
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -31,5 +34,29 @@ public class VelocityPluginApplyTest {
         assertNotNull("Project is missing velocity task", task);
         assertTrue("Velocity task is the wrong type", task instanceof DefaultTask);
         assertTrue("Velocity task should be enabled", ((DefaultTask) task).isEnabled());
+    }
+
+    @Test
+    public void setCustomFilter() {
+        project.apply(Collections.singletonMap("plugin", "java"));
+        project.apply(Collections.singletonMap("plugin", "velocity"));
+
+        ExtensionContainer extensions = project.getExtensions();
+        VelocityPluginExtension dsl = (VelocityPluginExtension) extensions.getByName("velocity");
+
+        // Retrieve plugin task and verify default values
+        VelocityTask task = (VelocityTask) project.getTasks().findByName("velocityVpp");
+        String filter = task.getFilter();
+        assertEquals(VelocityPluginExtension.DEFAULT_FILTER_REGEX, filter);
+
+        // Modify the PluginExtensions filter
+        String testValue = "myFilter";
+        dsl.filter = testValue;
+
+        // Verify that plugin task has the new value for filter
+        task = (VelocityTask) project.getTasks().findByName("velocityVpp");
+        filter = task.getFilter();
+
+        assertEquals(testValue, filter);
     }
 }

--- a/src/test/java/org/anarres/gradle/plugin/velocity/VelocityPluginConfigurationTest.java
+++ b/src/test/java/org/anarres/gradle/plugin/velocity/VelocityPluginConfigurationTest.java
@@ -1,0 +1,49 @@
+package org.anarres.gradle.plugin.velocity;
+
+import java.util.Collections;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Class for testing configurations in VelocityPluginExtension
+ */
+public class VelocityPluginConfigurationTest
+{
+    Project project;
+
+    @Before
+    public void setUp() {
+        project = ProjectBuilder.builder().build();
+    }
+
+    @Test
+    public void setCustomFilter() {
+        project.apply(Collections.singletonMap("plugin", "java"));
+        project.apply(Collections.singletonMap("plugin", "velocity"));
+
+        ExtensionContainer extensions = project.getExtensions();
+        VelocityPluginExtension dsl = (VelocityPluginExtension) extensions.getByName("velocity");
+
+        // Retrieve plugin task and verify default values
+        VelocityTask task = (VelocityTask) project.getTasks().findByName("velocityVpp");
+        String filter = task.getFilter();
+        assertEquals(VelocityPluginExtension.DEFAULT_FILTER_REGEX, filter);
+
+        // Modify the PluginExtensions filter
+        String testValue = "myFilter";
+        dsl.filter = testValue;
+
+        // Verify that plugin task has the new value for filter
+        task = (VelocityTask) project.getTasks().findByName("velocityVpp");
+        filter = task.getFilter();
+
+        assertEquals(testValue, filter);
+    }
+
+}


### PR DESCRIPTION
I've added the filter property to the configuration block, so that one can configure it directly instead of calling method setFilter() on velocityVpp-task.

Oh, and in my master branch I also applied the maven-publish plugin (to use task publishToMavenLocal for easy testing with my other project) and the eclipse plugins, but these can be removed.
